### PR TITLE
Use Build Arguments for Credentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get install -qq -y nodejs
 # install software-properties-common for add-apt-repository
 RUN apt-get install -qq -y software-properties-common
 
+ARG RAILS_LTS_PASS
+
 # clean up ruby / gems / bundler
 RUN gem update --system
 RUN gem update bundler
@@ -18,4 +20,4 @@ RUN gem update bundler
 RUN GEM_HOME=/usr/local/lib/ruby/gems/2.2.0 gem cleanup bundler
 
 # install base version of rails
-RUN gem install rails -v 3.2.22.5
+RUN gem install rails -v 3.2.22.9 --source "https://concord:$RAILS_LTS_PASS@gems.railslts.com"

--- a/README.md
+++ b/README.md
@@ -2,4 +2,8 @@
 
 Base Docker Rails image for the portal and LARA.
 
-Currently uses Rails 3.2.22.
+Currently uses Rails LTS 3.2.22.
+
+To build new image:
+
+`docker build . -t concordconsortium/docker-rails-base-2.2.6:new-tag-here --build-arg RAILS_LTS_PASS=replace-with-password`


### PR DESCRIPTION
This PR adds the ability pass in build arguments for the Rails LTS credentials. It also updates the readme with the build command.