### PR TITLE
Configure Bundler with Rails LTS credentials

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,8 @@ RUN gem update bundler
 # location where bundler is installed
 RUN GEM_HOME=/usr/local/lib/ruby/gems/2.2.0 gem cleanup bundler
 
-# Configure bundler with rails lts credentials
+# Install base version of Rails
+RUN gem install rails -v 3.2.22.9 --source "https://concord:$RAILS_LTS_PASS@gems.railslts.com"
+
+# Configure Bundler with Rails LTS credentials
 RUN bundle config gems.railslts.com concord:$RAILS_LTS_PASS

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,5 @@ RUN gem update bundler
 # location where bundler is installed
 RUN GEM_HOME=/usr/local/lib/ruby/gems/2.2.0 gem cleanup bundler
 
-# install base version of rails
-RUN gem install rails -v 3.2.22.9 --source "https://concord:$RAILS_LTS_PASS@gems.railslts.com"
+# Configure bundler with rails lts credentials
+RUN bundle config gems.railslts.com concord:$RAILS_LTS_PASS


### PR DESCRIPTION
There was a flaw in our validation of the previous approach where we install the gem in the base container. Nate had the LTS gems installed into the `/bundle` volume but did not realize it. So, when he deleted his images and built everything from scratch to verify `bundle install` would use the Rails LTS gem installed in the base image it appeared to work. BUT- only because he already had the gems in the `/bundle` volume.

So, we're going to configure Bundler with the credentials instead which I think is better anyway. This way we can upgrade Rails LTS patch releases without rebuilding the base image